### PR TITLE
Add first-class Codex provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Kong solves this by building rich context windows from Ghidra's program analysis
 - **Syntactic Normalization**: Decompiler output is cleaned up (modulo recovery, negative literal reconstruction, dead assignment removal) before reaching the LLM, reducing noise and token waste. 
 - **Agentic Deobfuscation**: Kong uses an agentic deobfuscation pipeline which can identify and remove obfuscation techniques (Control flow flattening, bogus control flow, instruction substitution, string encryption, VM protection, etc.) from the decompiler output.
 - **Eval Framework**: Built-in evaluation harness that scores analysis output against ground-truth source code, measuring symbol accuracy (word-based Jaccard) and type accuracy (signature component scoring).
-- **Multi-Provider LLM Support**: Works with Anthropic (Claude) and OpenAI (GPT-4o) out of the box. An interactive setup wizard configures providers and smart routing auto-selects whichever has a valid key.
-- **Cost-Tracking**: Tracks token usage and costs per model across providers, with provider-aware pricing.
+- **Multi-Provider LLM Support**: Works with Anthropic (Claude), OpenAI (GPT-4o), Codex (ChatGPT OAuth), and custom OpenAI-compatible endpoints. The setup wizard configures providers and smart routing auto-selects whichever has valid credentials.
+- **Cost-Tracking**: Tracks token usage and costs per model where API pricing exists, with token-only accounting for Codex and custom endpoints.
 
 ## Supported Architectures
 
@@ -129,7 +129,7 @@ Kong uses a five-phase pipeline orchestrated by a supervisor that coordinates tr
 
 - **Runtime**: Python 3.11+, managed with [uv](https://github.com/astral-sh/uv)
 - **Binary analysis**: [Ghidra](https://ghidra-sre.org/) via [PyGhidra](https://github.com/NationalSecurityAgency/ghidra/tree/master/Ghidra/Features/PyGhidra) (in-process, JPype)
-- **LLM**: [Anthropic SDK](https://github.com/anthropics/anthropic-sdk-python) (Claude) and [OpenAI SDK](https://github.com/openai/openai-python) (GPT-4o)
+- **LLM**: [Anthropic SDK](https://github.com/anthropics/anthropic-sdk-python) (Claude), [OpenAI SDK](https://github.com/openai/openai-python) (GPT-4o), and the ChatGPT Codex backend for OAuth-backed Codex analysis
 - **Symbolic analysis**: [z3-solver](https://github.com/Z3Prover/z3)
 - **CLI**: [Click](https://click.palletsprojects.com/)
 - **TUI**: [Textual](https://textual.textualize.io/)
@@ -145,9 +145,11 @@ Kong uses a five-phase pipeline orchestrated by a supervisor that coordinates tr
 - **uv** — Python package manager ([Install uv](https://docs.astral.sh/uv/getting-started/installation/))
 - **Ghidra** — The National Security Agency's reverse engineering framework ([Install Ghidra](https://ghidra-sre.org/InstallationGuide.html))
 - **JDK 21+** — Required by Ghidra ([Adoptium](https://adoptium.net/))
-- **LLM API key** — At least one of:
+- **LLM credentials** — At least one of:
   - [Anthropic](https://console.anthropic.com/settings/keys) (Claude)
-  - [OpenAI](https://platform.openai.com/api-keys) (GPT-4o)
+  - [OpenAI API key](https://platform.openai.com/api-keys) (GPT-4o)
+  - A local Codex login (`codex`, then "Sign in with ChatGPT") for the `codex` provider
+  - A custom OpenAI-compatible endpoint
 
 ### Quick Start
 
@@ -155,10 +157,13 @@ Kong uses a five-phase pipeline orchestrated by a supervisor that coordinates tr
 # 1. Install Kong
 uv pip install kong-re
 
-# 2. Set your API key(s)
+# 2. Set your credentials
 export ANTHROPIC_API_KEY="sk-ant-..."
 # and/or
 export OPENAI_API_KEY="sk-..."
+
+# or sign in with Codex for the Codex provider
+codex
 
 # 3. Run the setup wizard (first time only)
 kong setup
@@ -167,7 +172,9 @@ kong setup
 kong analyze ./path/to/stripped_binary
 ```
 
-The setup wizard lets you pick which LLM providers to use and sets a default. Kong auto-detects your Ghidra and JDK installations, loads the binary into an in-process Ghidra instance, and runs the full pipeline.
+The setup wizard lets you pick which LLM providers to use and sets a default. The `codex` provider uses your local ChatGPT/Codex login from `~/.codex/auth.json` and talks directly to the ChatGPT Codex backend. The `openai` provider still uses the normal OpenAI API and can optionally reuse a local Codex login as its credential source. Kong auto-detects your Ghidra and JDK installations, loads the binary into an in-process Ghidra instance, and runs the full pipeline.
+
+Note: Codex/ChatGPT access and OpenAI API billing are managed separately. If Kong detects Codex OAuth but OpenAI requests still fail, enable API billing for your OpenAI project or provide `OPENAI_API_KEY`.
 
 #### From source
 
@@ -184,7 +191,8 @@ uv run kong analyze ./path/to/stripped_binary
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `ANTHROPIC_API_KEY` | At least one | Anthropic API key (Claude) |
-| `OPENAI_API_KEY` | At least one | OpenAI API key (GPT-4o) |
+| `OPENAI_API_KEY` | No | OpenAI API key (GPT-4o). Optional if Kong can reuse a local Codex login. |
+| `CODEX_HOME` | No | Override the Codex config directory used to locate `auth.json`. |
 | `GHIDRA_INSTALL_DIR` | No | Path to Ghidra installation (auto-detected if not set) |
 | `JAVA_HOME` | No | Path to JDK (auto-detected if not set) |
 | `KONG_CONFIG_DIR` | No | Override config directory (default: `~/.config/kong`) |
@@ -200,9 +208,11 @@ kong analyze ./binary
 
 # Analyze with a specific provider
 kong analyze ./binary --provider openai
+kong analyze ./binary --provider codex
 
 # Override the model
 kong analyze ./binary --provider openai --model gpt-4o-mini
+kong analyze ./binary --provider codex --model gpt-5-codex
 
 # Show binary metadata without running analysis
 kong info ./binary

--- a/kong/__main__.py
+++ b/kong/__main__.py
@@ -27,8 +27,10 @@ from kong.config import GhidraConfig, KongConfig, LLMConfig, LLMProvider, Output
 from kong.db import get_custom_config, get_default_provider, get_enabled_providers, is_setup_complete, save_setup
 from kong.evals.harness import score as eval_score
 from kong.ghidra.client import GhidraClient, GhidraClientError
+from kong.llm.codex_auth import resolve_codex_credential
+from kong.llm.codex_client import CodexClient
+from kong.llm.openai_auth import resolve_openai_credential
 from kong.llm.usage import TokenUsage
-from kong.banner import _ENV_VARS, _KEY_EXAMPLES, _KEY_URLS
 from kong.llm.openai_client import OpenAIClient
 from kong.llm.client import AnthropicClient
 from kong.tui.app import KongApp
@@ -43,15 +45,18 @@ console = Console()
 _DEFAULT_MODELS: dict[LLMProvider, str] = {
     LLMProvider.ANTHROPIC: "claude-opus-4-6",
     LLMProvider.OPENAI: "gpt-4o",
+    LLMProvider.CODEX: "gpt-5-codex",
 }
 
 _PROVIDER_LABELS: dict[LLMProvider, str] = {
     LLMProvider.ANTHROPIC: "Anthropic (Claude)",
     LLMProvider.OPENAI: "OpenAI (GPT-4o)",
+    LLMProvider.CODEX: "Codex (ChatGPT OAuth)",
     LLMProvider.CUSTOM: "Custom (OpenAI-compatible)",
 }
 
 _NOT_NEEDED_STR = "not-needed"
+
 
 def create_llm_client(config: LLMConfig) -> LLMClient:
     """Instantiate the appropriate LLM client based on provider config."""
@@ -68,6 +73,11 @@ def create_llm_client(config: LLMConfig) -> LLMClient:
             model=model,
             base_url=config.base_url,
             api_key=api_key,
+        )
+    if config.provider is LLMProvider.CODEX:
+        return CodexClient(
+            model=model,
+            max_output_tokens=config.max_output_tokens,
         )
     if config.provider is LLMProvider.OPENAI:
         return OpenAIClient(model=model, api_key=config.api_key)
@@ -102,11 +112,16 @@ def resolve_provider(cli_override: str | None = None, base_url: str | None = Non
             return provider
         if check_api_key(provider):
             return provider
-        env_var = _ENV_VARS.get(provider, "unknown")
-        console.print(
-            f"[yellow]Warning:[/yellow] --provider {provider.value} specified "
-            f"but {env_var} is not set."
-        )
+        if provider is LLMProvider.CODEX:
+            console.print(
+                "[yellow]Warning:[/yellow] --provider codex specified but no local Codex OAuth login was found."
+            )
+        else:
+            env_var = _ENV_VARS.get(provider, "unknown")
+            console.print(
+                f"[yellow]Warning:[/yellow] --provider {provider.value} specified "
+                f"but {env_var} is not set."
+            )
         raise SystemExit(1)
 
     default = get_default_provider()
@@ -122,6 +137,10 @@ def resolve_provider(cli_override: str | None = None, base_url: str | None = Non
             return provider
 
     console.print("[red]No API keys found for any configured provider.[/red]")
+    if LLMProvider.OPENAI in get_enabled_providers():
+        console.print("OpenAI can also use your local Codex OAuth login.")
+    if LLMProvider.CODEX in get_enabled_providers():
+        console.print("Codex requires a local ChatGPT login. Run [bold]codex[/bold] first.")
     console.print("Run [bold cyan]kong setup[/bold cyan] to configure providers.")
     raise SystemExit(1)
 
@@ -151,7 +170,7 @@ def cli(ctx: click.Context, verbose: bool) -> None:
 
 def _print_final_stats(supervisor: Supervisor, llm_client: LLMClient) -> None:
     stats = supervisor.stats
-    is_custom = supervisor.config.llm.provider is LLMProvider.CUSTOM
+    is_non_billable = supervisor.config.llm.provider in (LLMProvider.CUSTOM, LLMProvider.CODEX)
     console.print()
     console.print(
         f"[bold]Results:[/bold] {stats.named}/{stats.total_functions} functions named "
@@ -170,7 +189,7 @@ def _print_final_stats(supervisor: Supervisor, llm_client: LLMClient) -> None:
             f"{usage.total_tokens:,} total"
         )
         for model_name, mu in usage.by_model.items():
-            if is_custom:
+            if is_non_billable:
                 console.print(
                     f"  {model_name}: {mu.calls} calls, "
                     f"{mu.input_tokens:,} in / {mu.output_tokens:,} out"
@@ -180,8 +199,9 @@ def _print_final_stats(supervisor: Supervisor, llm_client: LLMClient) -> None:
                     f"  {model_name}: {mu.calls} calls, "
                     f"${mu.cost_usd(model_name):.4f}"
                 )
-    if is_custom:
-        console.print("[dim]Cost tracking disabled for custom provider[/dim]")
+    if is_non_billable:
+        provider_name = "custom provider" if supervisor.config.llm.provider is LLMProvider.CUSTOM else "Codex"
+        console.print(f"[dim]Cost tracking disabled for {provider_name}[/dim]")
     else:
         total_cost = getattr(llm_client, "total_cost_usd", 0.0)
         console.print(f"[bold]Cost:[/bold] ${total_cost:.4f}")
@@ -210,7 +230,7 @@ def _print_final_stats(supervisor: Supervisor, llm_client: LLMClient) -> None:
     "--provider", "-p",
     type=click.Choice([p.value for p in LLMProvider], case_sensitive=False),
     default=None,
-    help="LLM provider (anthropic, openai, or custom).",
+    help="LLM provider (anthropic, openai, codex, or custom).",
 )
 @click.option("--model", "-m", default=None, help="Override the LLM model name.")
 @click.option("--base-url", default=None, help="Custom OpenAI-compatible endpoint URL.")
@@ -287,10 +307,25 @@ def analyze(
         console.print("[red]Could not connect to LLM endpoint.[/red]")
         if llm_provider is LLMProvider.CUSTOM:
             console.print(f"Ensure your server is running at {config.llm.base_url}")
+        elif llm_provider is LLMProvider.CODEX:
+            if resolve_codex_credential() is None:
+                console.print("Run [bold]codex[/bold] to sign in with ChatGPT first.")
+            else:
+                console.print("Your local Codex login was found, but the ChatGPT Codex backend rejected the request.")
+        elif llm_provider is LLMProvider.OPENAI:
+            credential = resolve_openai_credential()
+            if credential and credential.source == "codex_oauth":
+                console.print(
+                    "Codex OAuth was detected, but OpenAI API billing and scopes are managed separately."
+                )
+                console.print(
+                    "If this persists, enable API billing for your OpenAI project or set OPENAI_API_KEY."
+                )
         raise SystemExit(1)
 
-    if llm_provider is LLMProvider.CUSTOM:
-        console.print("[dim]Cost tracking disabled for custom provider (token counts still recorded)[/dim]")
+    if llm_provider in (LLMProvider.CUSTOM, LLMProvider.CODEX):
+        label = "custom provider" if llm_provider is LLMProvider.CUSTOM else "Codex"
+        console.print(f"[dim]Cost tracking disabled for {label} (token counts still recorded)[/dim]")
 
     binary_path = Path(binary).resolve()
 
@@ -432,11 +467,13 @@ def setup() -> None:
     console.print()
     console.print(f"  [bold]1[/bold]) Anthropic (Claude){_current_marker(LLMProvider.ANTHROPIC)}")
     console.print(f"  [bold]2[/bold]) OpenAI (GPT-4o){_current_marker(LLMProvider.OPENAI)}")
-    console.print(f"  [bold]3[/bold]) Custom endpoint (OpenAI-compatible){_current_marker(LLMProvider.CUSTOM)}")
-    console.print("  [bold]4[/bold]) Anthropic + OpenAI")
+    console.print(f"  [bold]3[/bold]) Codex (ChatGPT OAuth){_current_marker(LLMProvider.CODEX)}")
+    console.print(f"  [bold]4[/bold]) Custom endpoint (OpenAI-compatible){_current_marker(LLMProvider.CUSTOM)}")
+    console.print("  [bold]5[/bold]) Anthropic + OpenAI")
+    console.print("  [bold]6[/bold]) Anthropic + Codex")
     console.print()
 
-    choice = Prompt.ask("Choice", choices=["1", "2", "3", "4"], console=console)
+    choice = Prompt.ask("Choice", choices=["1", "2", "3", "4", "5", "6"], console=console)
     choice_int = int(choice)
 
     custom_config: dict[str, str] | None = None
@@ -445,9 +482,13 @@ def setup() -> None:
     elif choice_int == 2:
         enabled = [LLMProvider.OPENAI]
     elif choice_int == 3:
+        enabled = [LLMProvider.CODEX]
+    elif choice_int == 4:
         enabled = [LLMProvider.CUSTOM]
-    else:
+    elif choice_int == 5:
         enabled = [LLMProvider.ANTHROPIC, LLMProvider.OPENAI]
+    else:
+        enabled = [LLMProvider.ANTHROPIC, LLMProvider.CODEX]
 
     if LLMProvider.CUSTOM in enabled:
         saved_url = saved_custom.get("custom_base_url", "")
@@ -515,16 +556,46 @@ def setup() -> None:
         if p is LLMProvider.CUSTOM:
             any_key_found = True
             continue
+        if p is LLMProvider.CODEX:
+            credential = resolve_codex_credential()
+            if credential is not None:
+                console.print(
+                    f"  {_PROVIDER_LABELS[p]:25s} [green]Found[/green] (via {credential.source_label})"
+                )
+                any_key_found = True
+            else:
+                console.print(f"  {_PROVIDER_LABELS[p]:25s} [yellow]Not set[/yellow]")
+                console.print("    Sign in locally with [bold]codex[/bold]")
+            console.print()
+            continue
         env_var = _ENV_VARS[p]
         if check_api_key(p):
-            key = os.environ.get(env_var, "")
-            masked = key[:7] + "..." + key[-4:] if len(key) > 11 else "***"
-            console.print(f"  {_PROVIDER_LABELS[p]:25s} [green]Found[/green] ({masked})")
+            if p is LLMProvider.OPENAI:
+                credential = resolve_openai_credential()
+                if credential is not None:
+                    if credential.masked_value:
+                        console.print(
+                            f"  {_PROVIDER_LABELS[p]:25s} [green]Found[/green] "
+                            f"({credential.masked_value} via {credential.source_label})"
+                        )
+                    else:
+                        console.print(
+                            f"  {_PROVIDER_LABELS[p]:25s} [green]Found[/green] "
+                            f"(via {credential.source_label})"
+                        )
+                else:
+                    console.print(f"  {_PROVIDER_LABELS[p]:25s} [green]Found[/green]")
+            else:
+                key = os.environ.get(env_var, "")
+                masked = key[:7] + "..." + key[-4:] if len(key) > 11 else "***"
+                console.print(f"  {_PROVIDER_LABELS[p]:25s} [green]Found[/green] ({masked})")
             any_key_found = True
         else:
             console.print(f"  {_PROVIDER_LABELS[p]:25s} [yellow]Not set[/yellow]")
             console.print(f"    Get your key at: [bold]{_KEY_URLS[p]}[/bold]")
             console.print(f"    [bold]export {env_var}={_KEY_EXAMPLES[p]}[/bold]")
+            if p is LLMProvider.OPENAI:
+                console.print("    Or sign in locally with [bold]codex[/bold]")
         console.print()
 
     non_custom = [p for p in enabled if p is not LLMProvider.CUSTOM]

--- a/kong/banner.py
+++ b/kong/banner.py
@@ -11,6 +11,8 @@ from rich.text import Text
 
 from kong import __version__
 from kong.config import LLMProvider
+from kong.llm.codex_auth import resolve_codex_credential
+from kong.llm.openai_auth import resolve_openai_credential
 
 KONG_ASCII = r"""
  ██╗  ██╗ ██████╗ ███╗   ██╗ ██████╗
@@ -86,6 +88,11 @@ def _load_dotenv(provider: LLMProvider) -> None:
 
 
 def check_api_key(provider: LLMProvider) -> bool:
+    if provider is LLMProvider.CODEX:
+        return resolve_codex_credential() is not None
+    if provider is LLMProvider.OPENAI:
+        _load_dotenv(provider)
+        return resolve_openai_credential() is not None
     env_var = _env_var_for(provider)
     if env_var is None:
         return True
@@ -95,6 +102,11 @@ def check_api_key(provider: LLMProvider) -> bool:
 
 def print_setup_needed(console: Console, provider: LLMProvider = LLMProvider.ANTHROPIC) -> None:
     env_var = _env_var_for(provider)
+    if provider is LLMProvider.CODEX:
+        console.print()
+        console.print("[bold red]Codex OAuth is not configured.[/bold red]")
+        console.print("Run [bold cyan]codex[/bold cyan] to sign in with ChatGPT, then rerun [bold cyan]kong setup[/bold cyan].")
+        return
     if env_var is None:
         console.print()
         console.print("[bold red]Custom provider not configured.[/bold red]")
@@ -103,12 +115,20 @@ def print_setup_needed(console: Console, provider: LLMProvider = LLMProvider.ANT
     console.print()
     console.print(f"[bold red]{env_var} is not set.[/bold red]")
     console.print()
-    console.print(f"Kong requires a {provider.display_name} API key to analyze binaries.")
+    if provider is LLMProvider.OPENAI:
+        console.print("Kong requires OpenAI credentials to analyze binaries.")
+        console.print("You can use either OPENAI_API_KEY or a local Codex OAuth login.")
+    else:
+        console.print(f"Kong requires a {provider.display_name} API key to analyze binaries.")
     console.print("Run [bold cyan]kong setup[/bold cyan] for guided configuration.")
     console.print()
     key_example = _KEY_EXAMPLES.get(provider, "your-key-here")
     console.print("Or set it directly:")
     console.print(f"  [bold]export {env_var}={key_example}[/bold]")
+    if provider is LLMProvider.OPENAI:
+        console.print()
+        console.print("Or sign in with Codex:")
+        console.print("  [bold]codex[/bold]")
 
 
 def print_analyze_header(

--- a/kong/config.py
+++ b/kong/config.py
@@ -12,6 +12,7 @@ from kong.ghidra.environment import find_ghidra_install
 class LLMProvider(Enum):
     ANTHROPIC = "anthropic"
     OPENAI = "openai"
+    CODEX = "codex"
     CUSTOM = "custom"
 
     @property
@@ -19,6 +20,7 @@ class LLMProvider(Enum):
         return {
             LLMProvider.ANTHROPIC: "Anthropic",
             LLMProvider.OPENAI: "OpenAI",
+            LLMProvider.CODEX: "Codex",
             LLMProvider.CUSTOM: "Custom",
         }[self]
 

--- a/kong/export/structured.py
+++ b/kong/export/structured.py
@@ -23,7 +23,11 @@ def _build_binary_section(data: ExportData) -> dict[str, str | int]:
 
 def _build_stats_section(data: ExportData) -> dict[str, int | float | bool]:
     s = data.stats
-    cost_tracking = data.provider is not LLMProvider.CUSTOM if data.provider else True
+    cost_tracking = (
+        data.provider not in (LLMProvider.CUSTOM, LLMProvider.CODEX)
+        if data.provider
+        else True
+    )
     return {
         "total_functions": s.total_functions,
         "analyzed": s.analyzed,

--- a/kong/llm/codex_auth.py
+++ b/kong/llm/codex_auth.py
@@ -95,6 +95,7 @@ def refresh_codex_credential(credential: CodexCredential | None = None) -> Codex
     auth_path = current.auth_path or codex_auth_path()
     auth_path.parent.mkdir(parents=True, exist_ok=True)
     auth_path.write_text(json.dumps(updated, indent=2), encoding="utf-8")
+    _restrict_auth_file_permissions(auth_path)
 
     return CodexCredential(
         access_token=access_token,
@@ -165,3 +166,10 @@ def _decode_jwt_payload(token: str) -> dict[str, Any] | None:
     if not isinstance(parsed, dict):
         return None
     return parsed
+
+
+def _restrict_auth_file_permissions(path: Path) -> None:
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass

--- a/kong/llm/codex_auth.py
+++ b/kong/llm/codex_auth.py
@@ -1,0 +1,167 @@
+"""Helpers for resolving and refreshing Codex OAuth credentials."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+TOKEN_URL = "https://auth.openai.com/oauth/token"
+JWT_CLAIM_PATH = "https://api.openai.com/auth"
+
+
+@dataclass(frozen=True)
+class CodexCredential:
+    access_token: str
+    account_id: str
+    refresh_token: str | None = None
+    auth_path: Path | None = None
+
+    @property
+    def source_label(self) -> str:
+        return "Codex OAuth"
+
+
+def codex_auth_path() -> Path:
+    codex_home = os.environ.get("CODEX_HOME")
+    if codex_home:
+        return Path(codex_home) / "auth.json"
+    return Path.home() / ".codex" / "auth.json"
+
+
+def resolve_codex_credential() -> CodexCredential | None:
+    auth_path = codex_auth_path()
+    if not auth_path.is_file():
+        return None
+
+    try:
+        auth = json.loads(auth_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    return _credential_from_auth(auth, auth_path=auth_path)
+
+
+def refresh_codex_credential(credential: CodexCredential | None = None) -> CodexCredential | None:
+    current = credential or resolve_codex_credential()
+    if current is None or not current.refresh_token:
+        return None
+
+    payload = urllib.parse.urlencode({
+        "grant_type": "refresh_token",
+        "refresh_token": current.refresh_token,
+        "client_id": CLIENT_ID,
+    }).encode("utf-8")
+    request = urllib.request.Request(
+        TOKEN_URL,
+        data=payload,
+        method="POST",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    with urllib.request.urlopen(request, timeout=30) as response:
+        data = json.loads(response.read().decode("utf-8"))
+
+    access_token = data.get("access_token")
+    refresh_token = data.get("refresh_token")
+    if not isinstance(access_token, str) or not access_token:
+        return None
+    if not isinstance(refresh_token, str) or not refresh_token:
+        return None
+
+    account_id = current.account_id or _extract_account_id(access_token) or ""
+    if not account_id:
+        return None
+
+    updated = {
+        "auth_mode": "chatgpt",
+        "OPENAI_API_KEY": None,
+        "tokens": {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "account_id": account_id,
+        },
+        "last_refresh": int(time.time()),
+    }
+
+    auth_path = current.auth_path or codex_auth_path()
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+    auth_path.write_text(json.dumps(updated, indent=2), encoding="utf-8")
+
+    return CodexCredential(
+        access_token=access_token,
+        account_id=account_id,
+        refresh_token=refresh_token,
+        auth_path=auth_path,
+    )
+
+
+def _credential_from_auth(auth: dict[str, Any], *, auth_path: Path) -> CodexCredential | None:
+    tokens = auth.get("tokens")
+    if not isinstance(tokens, dict):
+        return None
+
+    access_token = tokens.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        return None
+
+    refresh_token = tokens.get("refresh_token")
+    if not isinstance(refresh_token, str) or not refresh_token:
+        refresh_token = None
+
+    account_id = tokens.get("account_id")
+    if not isinstance(account_id, str) or not account_id:
+        account_id = _extract_account_id(access_token)
+    if not account_id:
+        return None
+
+    return CodexCredential(
+        access_token=access_token,
+        account_id=account_id,
+        refresh_token=refresh_token,
+        auth_path=auth_path,
+    )
+
+
+def _extract_account_id(token: str) -> str | None:
+    payload = _decode_jwt_payload(token)
+    if payload is None:
+        return None
+
+    direct = payload.get("account_id")
+    if isinstance(direct, str) and direct:
+        return direct
+
+    nested = payload.get(JWT_CLAIM_PATH)
+    if isinstance(nested, dict):
+        for key in ("chatgpt_account_id", "account_id"):
+            value = nested.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return None
+
+
+def _decode_jwt_payload(token: str) -> dict[str, Any] | None:
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+
+    payload = parts[1]
+    padding = "=" * (-len(payload) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(payload + padding)
+        parsed = json.loads(decoded.decode("utf-8"))
+    except (ValueError, json.JSONDecodeError):
+        return None
+
+    if not isinstance(parsed, dict):
+        return None
+    return parsed

--- a/kong/llm/codex_client.py
+++ b/kong/llm/codex_client.py
@@ -1,0 +1,353 @@
+"""Codex ChatGPT-backend client for function analysis."""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+from kong.agent.analyzer import Analyzer, LLMResponse
+from kong.agent.prompts import BATCH_OUTPUT_SCHEMA, BATCH_SYSTEM_PROMPT, OUTPUT_SCHEMA, SYSTEM_PROMPT
+from kong.llm.codex_auth import CodexCredential, refresh_codex_credential, resolve_codex_credential
+from kong.llm.tools import ToolExecutor
+from kong.llm.usage import TokenUsage
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "gpt-5-codex"
+CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
+
+
+class CodexClientError(RuntimeError):
+    """Raised when the Codex backend rejects a request."""
+
+
+@dataclass
+class _CodexEnvelope:
+    output_text: str
+    response: dict[str, Any]
+    input_tokens: int
+    output_tokens: int
+    outputs: list[dict[str, Any]]
+
+
+class CodexClient:
+    """Concrete LLM client using the ChatGPT Codex backend."""
+
+    def __init__(
+        self,
+        model: str = DEFAULT_MODEL,
+        max_output_tokens: int | None = None,
+    ) -> None:
+        self.model = model
+        self.max_output_tokens = max_output_tokens
+        self.usage = TokenUsage()
+
+    def analyze_function(self, prompt: str, *, model: str | None = None) -> LLMResponse:
+        effective_model = model or self.model
+        envelope = self._request(
+            instructions=f"{SYSTEM_PROMPT}\n\n{OUTPUT_SCHEMA}",
+            input_items=[self._user_message(prompt)],
+            model=effective_model,
+        )
+
+        result = Analyzer.parse_llm_json(envelope.output_text)
+        result.input_tokens = envelope.input_tokens
+        result.output_tokens = envelope.output_tokens
+        result.raw = envelope.output_text
+        return result
+
+    def analyze_function_batch(self, prompt: str, *, model: str | None = None) -> list[LLMResponse]:
+        effective_model = model or self.model
+        envelope = self._request(
+            instructions=f"{BATCH_SYSTEM_PROMPT}\n\n{BATCH_OUTPUT_SCHEMA}",
+            input_items=[self._user_message(prompt)],
+            model=effective_model,
+        )
+
+        responses = Analyzer.parse_llm_json_batch(envelope.output_text)
+        for resp in responses:
+            resp.input_tokens = envelope.input_tokens
+            resp.output_tokens = envelope.output_tokens
+        return responses
+
+    def analyze_with_tools(
+        self,
+        prompt: str,
+        system: str,
+        tools: list[dict[str, Any]],
+        tool_executor: ToolExecutor,
+        max_rounds: int = 10,
+    ) -> LLMResponse:
+        input_items: list[dict[str, Any]] = [self._user_message(prompt)]
+        total_input = 0
+        total_output = 0
+        last_text = ""
+
+        for _ in range(max_rounds):
+            envelope = self._request(
+                instructions=f"{system}\n\n{OUTPUT_SCHEMA}",
+                input_items=input_items,
+                tools=self._convert_tools(tools),
+                model=self.model,
+            )
+
+            total_input += envelope.input_tokens
+            total_output += envelope.output_tokens
+            last_text = envelope.output_text
+
+            tool_calls = [item for item in envelope.outputs if item.get("type") == "function_call"]
+            if not tool_calls:
+                result = Analyzer.parse_llm_json(last_text)
+                result.input_tokens = total_input
+                result.output_tokens = total_output
+                result.raw = last_text
+                return result
+
+            for tool_call in tool_calls:
+                raw_args = tool_call.get("arguments", "") or "{}"
+                try:
+                    arguments = json.loads(raw_args)
+                except json.JSONDecodeError:
+                    arguments = {}
+
+                result_str = tool_executor.execute(tool_call["name"], arguments)
+                input_items.append({
+                    "type": "function_call",
+                    "call_id": tool_call["call_id"],
+                    "name": tool_call["name"],
+                    "arguments": raw_args,
+                })
+                input_items.append({
+                    "type": "function_call_output",
+                    "call_id": tool_call["call_id"],
+                    "output": result_str,
+                })
+
+        result = Analyzer.parse_llm_json(last_text)
+        result.input_tokens = total_input
+        result.output_tokens = total_output
+        result.raw = last_text
+        return result
+
+    @property
+    def total_cost_usd(self) -> float:
+        return 0.0
+
+    def probe(self) -> bool:
+        envelope = self._request(
+            instructions='Reply with exactly this JSON object: {"ok": true}',
+            input_items=[self._user_message("ping")],
+            model=self.model,
+        )
+        return '"ok"' in envelope.output_text
+
+    def _request(
+        self,
+        *,
+        instructions: str,
+        input_items: list[dict[str, Any]],
+        model: str,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> _CodexEnvelope:
+        credential = resolve_codex_credential()
+        if credential is None:
+            raise CodexClientError("Codex OAuth credentials not found. Run `codex` to sign in.")
+
+        last_error: Exception | None = None
+        for attempt in range(2):
+            try:
+                return self._perform_request(
+                    credential=credential,
+                    instructions=instructions,
+                    input_items=input_items,
+                    model=model,
+                    tools=tools,
+                )
+            except urllib.error.HTTPError as exc:
+                last_error = exc
+                if exc.code == 401 and credential.refresh_token and attempt == 0:
+                    refreshed = refresh_codex_credential(credential)
+                    if refreshed is not None:
+                        credential = refreshed
+                        continue
+                body = exc.read().decode("utf-8", "replace")
+                raise CodexClientError(self._format_http_error(exc.code, body)) from exc
+            except urllib.error.URLError as exc:
+                last_error = exc
+                raise CodexClientError(f"Could not connect to Codex backend: {exc.reason}") from exc
+
+        raise CodexClientError(str(last_error) if last_error else "Codex request failed")
+
+    def _perform_request(
+        self,
+        *,
+        credential: CodexCredential,
+        instructions: str,
+        input_items: list[dict[str, Any]],
+        model: str,
+        tools: list[dict[str, Any]] | None,
+    ) -> _CodexEnvelope:
+        payload: dict[str, Any] = {
+            "model": model,
+            "store": False,
+            "stream": True,
+            "instructions": instructions,
+            "input": input_items,
+            "include": ["reasoning.encrypted_content"],
+            "text": {"verbosity": "medium"},
+            "reasoning": {"effort": "medium"},
+        }
+        if self.max_output_tokens is not None:
+            payload["max_output_tokens"] = self.max_output_tokens
+        if tools:
+            payload["tools"] = tools
+
+        request = urllib.request.Request(
+            CODEX_RESPONSES_URL,
+            data=json.dumps(payload).encode("utf-8"),
+            method="POST",
+        )
+        for key, value in {
+            "Authorization": f"Bearer {credential.access_token}",
+            "chatgpt-account-id": credential.account_id,
+            "OpenAI-Beta": "responses=experimental",
+            "originator": "codex_cli_rs",
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+        }.items():
+            request.add_header(key, value)
+
+        with urllib.request.urlopen(request, timeout=120) as response:
+            events = self._read_sse_events(response)
+
+        completed_response: dict[str, Any] | None = None
+        output_text_parts: list[str] = []
+        for event_name, payload_data in events:
+            if event_name == "response.output_text.done":
+                text = payload_data.get("text")
+                if isinstance(text, str):
+                    output_text_parts.append(text)
+            elif event_name == "response.completed":
+                completed_response = payload_data.get("response")
+
+        if completed_response is None:
+            raise CodexClientError("Codex backend did not return a completed response.")
+
+        outputs = completed_response.get("output", [])
+        if not isinstance(outputs, list):
+            outputs = []
+
+        if not output_text_parts:
+            for item in outputs:
+                if item.get("type") != "message":
+                    continue
+                for part in item.get("content", []):
+                    text = part.get("text")
+                    if isinstance(text, str):
+                        output_text_parts.append(text)
+
+        usage = completed_response.get("usage") or {}
+        input_tokens = int(usage.get("input_tokens") or 0)
+        output_tokens = int(usage.get("output_tokens") or 0)
+        self._record_usage(model, input_tokens, output_tokens)
+
+        return _CodexEnvelope(
+            output_text="".join(output_text_parts),
+            response=completed_response,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            outputs=[item for item in outputs if isinstance(item, dict)],
+        )
+
+    @staticmethod
+    def _user_message(prompt: str) -> dict[str, Any]:
+        return {
+            "type": "message",
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": prompt},
+            ],
+        }
+
+    @staticmethod
+    def _convert_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        converted = []
+        for tool in tools:
+            converted.append({
+                "type": "function",
+                "name": tool["name"],
+                "description": tool["description"],
+                "parameters": tool["input_schema"],
+                "strict": True,
+            })
+        return converted
+
+    @staticmethod
+    def _read_sse_events(response: Any) -> list[tuple[str, dict[str, Any]]]:
+        events: list[tuple[str, dict[str, Any]]] = []
+        event_name = ""
+        data_lines: list[str] = []
+
+        while True:
+            raw_line = response.readline()
+            if not raw_line:
+                break
+
+            line = raw_line.decode("utf-8", "replace").rstrip("\r\n")
+            if not line:
+                if data_lines:
+                    data = "\n".join(data_lines)
+                    if data != "[DONE]":
+                        try:
+                            events.append((event_name, json.loads(data)))
+                        except json.JSONDecodeError:
+                            logger.debug("Skipping non-JSON SSE payload: %s", data[:200])
+                event_name = ""
+                data_lines = []
+                continue
+
+            if line.startswith("event:"):
+                event_name = line.split(":", 1)[1].strip()
+            elif line.startswith("data:"):
+                data_lines.append(line.split(":", 1)[1].lstrip())
+
+        return events
+
+    def _record_usage(self, model: str, input_tokens: int, output_tokens: int) -> None:
+        usage = self.usage._get(model)
+        usage.input_tokens += input_tokens
+        usage.output_tokens += output_tokens
+        usage.calls += 1
+        logger.debug(
+            "Codex [%s]: %d in / %d out tokens (total: %d calls)",
+            model,
+            input_tokens,
+            output_tokens,
+            self.usage.calls,
+        )
+
+    @staticmethod
+    def _format_http_error(status: int, body: str) -> str:
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError:
+            parsed = None
+
+        if isinstance(parsed, dict):
+            error = parsed.get("error")
+            if isinstance(error, dict):
+                message = error.get("message")
+                if isinstance(message, str) and message:
+                    return f"HTTP {status}: {message}"
+            detail = parsed.get("detail")
+            if isinstance(detail, str) and detail:
+                return f"HTTP {status}: {detail}"
+
+        body = body.strip()
+        if body:
+            return f"HTTP {status}: {body[:200]}"
+        return f"HTTP {status}"

--- a/kong/llm/codex_client.py
+++ b/kong/llm/codex_client.py
@@ -295,17 +295,12 @@ class CodexClient:
         while True:
             raw_line = response.readline()
             if not raw_line:
+                CodexClient._append_buffered_event(events, event_name, data_lines)
                 break
 
             line = raw_line.decode("utf-8", "replace").rstrip("\r\n")
             if not line:
-                if data_lines:
-                    data = "\n".join(data_lines)
-                    if data != "[DONE]":
-                        try:
-                            events.append((event_name, json.loads(data)))
-                        except json.JSONDecodeError:
-                            logger.debug("Skipping non-JSON SSE payload: %s", data[:200])
+                CodexClient._append_buffered_event(events, event_name, data_lines)
                 event_name = ""
                 data_lines = []
                 continue
@@ -316,6 +311,22 @@ class CodexClient:
                 data_lines.append(line.split(":", 1)[1].lstrip())
 
         return events
+
+    @staticmethod
+    def _append_buffered_event(
+        events: list[tuple[str, dict[str, Any]]],
+        event_name: str,
+        data_lines: list[str],
+    ) -> None:
+        if not data_lines:
+            return
+        data = "\n".join(data_lines)
+        if data == "[DONE]":
+            return
+        try:
+            events.append((event_name, json.loads(data)))
+        except json.JSONDecodeError:
+            logger.debug("Skipping non-JSON SSE payload: %s", data[:200])
 
     def _record_usage(self, model: str, input_tokens: int, output_tokens: int) -> None:
         usage = self.usage._get(model)

--- a/kong/llm/openai_auth.py
+++ b/kong/llm/openai_auth.py
@@ -1,0 +1,70 @@
+"""Helpers for resolving OpenAI credentials, including Codex OAuth."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+CredentialSource = Literal["env", "codex_api_key", "codex_oauth"]
+
+
+@dataclass(frozen=True)
+class OpenAICredential:
+    token: str
+    source: CredentialSource
+
+    @property
+    def source_label(self) -> str:
+        return {
+            "env": "OPENAI_API_KEY",
+            "codex_api_key": "Codex API key",
+            "codex_oauth": "Codex OAuth",
+        }[self.source]
+
+    @property
+    def masked_value(self) -> str | None:
+        if self.source == "codex_oauth":
+            return None
+        if len(self.token) <= 11:
+            return "***"
+        return self.token[:7] + "..." + self.token[-4:]
+
+
+def codex_auth_path() -> Path:
+    codex_home = os.environ.get("CODEX_HOME")
+    if codex_home:
+        return Path(codex_home) / "auth.json"
+    return Path.home() / ".codex" / "auth.json"
+
+
+def resolve_openai_credential() -> OpenAICredential | None:
+    env_key = os.environ.get("OPENAI_API_KEY")
+    if env_key:
+        return OpenAICredential(token=env_key, source="env")
+
+    auth_path = codex_auth_path()
+    if not auth_path.is_file():
+        return None
+
+    try:
+        auth = json.loads(auth_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    codex_api_key = auth.get("OPENAI_API_KEY")
+    if isinstance(codex_api_key, str) and codex_api_key:
+        return OpenAICredential(token=codex_api_key, source="codex_api_key")
+
+    tokens = auth.get("tokens")
+    if not isinstance(tokens, dict):
+        return None
+
+    access_token = tokens.get("access_token")
+    if isinstance(access_token, str) and access_token:
+        return OpenAICredential(token=access_token, source="codex_oauth")
+
+    return None

--- a/kong/llm/openai_client.py
+++ b/kong/llm/openai_client.py
@@ -15,6 +15,7 @@ import openai
 
 from kong.agent.analyzer import Analyzer, LLMResponse
 from kong.agent.prompts import BATCH_OUTPUT_SCHEMA, BATCH_SYSTEM_PROMPT, OUTPUT_SCHEMA, SYSTEM_PROMPT
+from kong.llm.openai_auth import resolve_openai_credential
 from kong.llm.tools import ToolExecutor
 from kong.llm.usage import TokenUsage
 
@@ -59,13 +60,33 @@ class OpenAIClient:
     ) -> None:
         self.model = model
         self.max_tokens = max_tokens
-        self._client = openai.OpenAI(api_key=api_key, base_url=base_url, max_retries=5)
+        self._explicit_api_key = api_key
+        self._base_url = base_url
+        self._resolved_api_key: str | None = None
+        self._client = self._make_client()
         self.usage = TokenUsage()
+
+    def _resolve_api_key(self) -> str | None:
+        if self._explicit_api_key is not None:
+            return self._explicit_api_key
+        credential = resolve_openai_credential()
+        return credential.token if credential else None
+
+    def _make_client(self) -> openai.OpenAI:
+        api_key = self._resolve_api_key()
+        self._resolved_api_key = api_key
+        return openai.OpenAI(api_key=api_key, base_url=self._base_url, max_retries=5)
+
+    def _get_client(self) -> openai.OpenAI:
+        api_key = self._resolve_api_key()
+        if api_key != self._resolved_api_key:
+            self._client = self._make_client()
+        return self._client
 
     def analyze_function(self, prompt: str, *, model: str | None = None) -> LLMResponse:
         """Send an analysis prompt and return parsed response (no tools)."""
         effective_model = model or self.model
-        response = self._client.chat.completions.create(
+        response = self._get_client().chat.completions.create(
             model=effective_model,
             max_tokens=self.max_tokens,
             response_format={"type": "json_object"},
@@ -87,7 +108,7 @@ class OpenAIClient:
     def analyze_function_batch(self, prompt: str, *, model: str | None = None) -> list[LLMResponse]:
         """Send a batch analysis prompt and return parsed list of responses."""
         effective_model = model or self.model
-        response = self._client.chat.completions.create(
+        response = self._get_client().chat.completions.create(
             model=effective_model,
             max_tokens=16384,
             messages=[
@@ -132,7 +153,7 @@ class OpenAIClient:
 
         last_text = ""
         for _ in range(max_rounds):
-            response = self._client.chat.completions.create(
+            response = self._get_client().chat.completions.create(
                 model=self.model,
                 max_tokens=self.max_tokens,
                 tools=openai_tools,

--- a/kong/llm/probe.py
+++ b/kong/llm/probe.py
@@ -12,6 +12,9 @@ import anthropic
 import openai
 
 from kong.config import LLMConfig, LLMProvider
+from kong.llm.codex_client import DEFAULT_MODEL as DEFAULT_CODEX_MODEL
+from kong.llm.codex_client import CodexClient, CodexClientError
+from kong.llm.openai_auth import resolve_openai_credential
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +24,8 @@ _PROBE_DUMMY_KEY = "not-needed"
 def probe_endpoint(config: LLMConfig) -> bool:
     if config.provider is LLMProvider.CUSTOM:
         return _probe_custom(config)
+    if config.provider is LLMProvider.CODEX:
+        return _probe_codex(config)
     if config.provider is LLMProvider.OPENAI:
         return _probe_openai(config)
     return _probe_anthropic(config)
@@ -47,15 +52,56 @@ def _probe_custom(config: LLMConfig) -> bool:
 
 
 def _probe_openai(config: LLMConfig) -> bool:
+    credential = resolve_openai_credential()
+    api_key = config.api_key
+    if api_key is None and credential is not None:
+        api_key = credential.token
+
     try:
-        client = openai.OpenAI(api_key=config.api_key, base_url=config.base_url)
+        client = openai.OpenAI(api_key=api_key, base_url=config.base_url)
         client.models.list()
         return True
+    except openai.PermissionDeniedError as e:
+        message = str(e)
+        if "api.model.read" not in message:
+            logger.warning("OpenAI credential was rejected: %s", message)
+            return False
+        return _probe_openai_inference(config, api_key)
     except openai.AuthenticationError:
         logger.warning("OpenAI API key is invalid")
         return False
     except openai.APIError as e:
         logger.warning("OpenAI API error: %s", e.message)
+        return False
+
+
+def _probe_openai_inference(config: LLMConfig, api_key: str | None) -> bool:
+    model = config.model or "gpt-4o-mini"
+    try:
+        client = openai.OpenAI(api_key=api_key, base_url=config.base_url)
+        client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "ping"}],
+            max_tokens=1,
+        )
+        return True
+    except openai.AuthenticationError:
+        logger.warning("OpenAI credential is invalid for inference")
+        return False
+    except openai.APIError as e:
+        logger.warning("OpenAI inference probe failed: %s", e.message)
+        return False
+
+
+def _probe_codex(config: LLMConfig) -> bool:
+    try:
+        client = CodexClient(
+            model=config.model or DEFAULT_CODEX_MODEL,
+            max_output_tokens=config.max_output_tokens,
+        )
+        return client.probe()
+    except CodexClientError as e:
+        logger.warning("Codex probe failed: %s", e)
         return False
 
 

--- a/kong/llm/usage.py
+++ b/kong/llm/usage.py
@@ -42,7 +42,7 @@ _ZERO_PRICING = PricingTier(0.0, 0.0, 0.0, 0.0)
 
 
 def get_pricing(model: str, provider: LLMProvider | None = None) -> PricingTier:
-    if provider is LLMProvider.CUSTOM:
+    if provider in (LLMProvider.CUSTOM, LLMProvider.CODEX):
         return _ZERO_PRICING
     return PRICING_REGISTRY.get(model, _DEFAULT_PRICING)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -178,7 +178,8 @@ class TestCreateLLMClient:
     @patch("kong.__main__.CodexClient")
     def test_codex_returns_codex_client(self, mock_codex_cls):
         config = LLMConfig(provider=LLMProvider.CODEX, model="gpt-5-codex", max_output_tokens=2048)
-        create_llm_client(config)
+        client = create_llm_client(config)
+        assert client is mock_codex_cls.return_value
         mock_codex_cls.assert_called_once_with(
             model="gpt-5-codex",
             max_output_tokens=2048,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -133,14 +133,36 @@ class TestCreateLLMClient:
         )
 
     @patch("kong.llm.openai_client.openai.OpenAI")
-    def test_openai_returns_openai_client_no_base_url(self, mock_openai_cls):
+    def test_openai_returns_openai_client_no_base_url(self, mock_openai_cls, tmp_path, monkeypatch):
         from kong.llm.openai_client import OpenAIClient
 
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
         config = LLMConfig(provider=LLMProvider.OPENAI, model="gpt-4o")
         client = create_llm_client(config)
         assert isinstance(client, OpenAIClient)
         mock_openai_cls.assert_called_once_with(
             api_key=None,
+            base_url=None,
+            max_retries=5,
+        )
+
+    @patch("kong.llm.openai_client.openai.OpenAI")
+    def test_openai_uses_codex_oauth_when_api_key_missing(self, mock_openai_cls, tmp_path, monkeypatch):
+        from kong.llm.openai_client import OpenAIClient
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        auth_path = tmp_path / "auth.json"
+        auth_path.write_text(
+            '{"OPENAI_API_KEY": null, "tokens": {"access_token": "oauth-token"}}'
+        )
+
+        config = LLMConfig(provider=LLMProvider.OPENAI, model="gpt-4o")
+        client = create_llm_client(config)
+        assert isinstance(client, OpenAIClient)
+        mock_openai_cls.assert_called_once_with(
+            api_key="oauth-token",
             base_url=None,
             max_retries=5,
         )
@@ -152,6 +174,15 @@ class TestCreateLLMClient:
         config = LLMConfig(provider=LLMProvider.ANTHROPIC, model="claude-opus-4-6")
         client = create_llm_client(config)
         assert isinstance(client, AnthropicClient)
+
+    @patch("kong.__main__.CodexClient")
+    def test_codex_returns_codex_client(self, mock_codex_cls):
+        config = LLMConfig(provider=LLMProvider.CODEX, model="gpt-5-codex", max_output_tokens=2048)
+        create_llm_client(config)
+        mock_codex_cls.assert_called_once_with(
+            model="gpt-5-codex",
+            max_output_tokens=2048,
+        )
 
 
 class TestResolveProviderCustom:
@@ -174,6 +205,17 @@ class TestResolveProviderCustom:
         )
         provider = resolve_provider()
         assert provider is LLMProvider.ANTHROPIC
+
+    def test_codex_can_be_selected_explicitly(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KONG_CONFIG_DIR", str(tmp_path))
+        codex_home = tmp_path / "codex-home"
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        codex_home.mkdir(parents=True, exist_ok=True)
+        (codex_home / "auth.json").write_text(
+            '{"tokens":{"access_token":"oauth-token","refresh_token":"refresh-token","account_id":"acct_123"}}'
+        )
+        provider = resolve_provider(cli_override="codex")
+        assert provider is LLMProvider.CODEX
 
 
 class TestValidateBaseUrl:
@@ -201,7 +243,7 @@ class TestSetupWizardCustom:
         result = runner.invoke(
             cli,
             ["setup"],
-            input="3\nhttp://localhost:11434/v1\nllama3:8b\n\n32000\n20\n4096\n",
+            input="4\nhttp://localhost:11434/v1\nllama3:8b\n\n32000\n20\n4096\n",
         )
         assert result.exit_code == 0
         from kong.db import get_default_provider
@@ -212,12 +254,12 @@ class TestSetupWizardCustom:
         assert cfg["custom_model"] == "llama3:8b"
         assert cfg["custom_max_prompt_chars"] == "32000"
 
-    def test_setup_option_4_is_anthropic_plus_openai(self, tmp_path, monkeypatch):
+    def test_setup_option_5_is_anthropic_plus_openai(self, tmp_path, monkeypatch):
         monkeypatch.setenv("KONG_CONFIG_DIR", str(tmp_path))
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test1234")
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test1234")
         runner = CliRunner()
-        result = runner.invoke(cli, ["setup"], input="4\n1\n")
+        result = runner.invoke(cli, ["setup"], input="5\n1\n")
         assert result.exit_code == 0
         from kong.db import get_enabled_providers
 
@@ -225,6 +267,21 @@ class TestSetupWizardCustom:
         assert LLMProvider.ANTHROPIC in enabled
         assert LLMProvider.OPENAI in enabled
         assert LLMProvider.CUSTOM not in enabled
+
+    def test_setup_option_3_is_codex(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KONG_CONFIG_DIR", str(tmp_path))
+        codex_home = tmp_path / "codex-home"
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        codex_home.mkdir(parents=True, exist_ok=True)
+        (codex_home / "auth.json").write_text(
+            '{"tokens":{"access_token":"oauth-token","refresh_token":"refresh-token","account_id":"acct_123"}}'
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["setup"], input="3\n")
+        assert result.exit_code == 0
+        from kong.db import get_default_provider
+
+        assert get_default_provider() is LLMProvider.CODEX
 
 
 class TestCustomProviderIntegration:

--- a/tests/test_codex_auth.py
+++ b/tests/test_codex_auth.py
@@ -26,8 +26,9 @@ def test_resolve_codex_credential_reads_auth_file(tmp_path, monkeypatch):
     assert credential.account_id == "acct_123"
 
 
+@patch("kong.llm.codex_auth.os.chmod")
 @patch("kong.llm.codex_auth.urllib.request.urlopen")
-def test_refresh_codex_credential_updates_auth_file(mock_urlopen, tmp_path, monkeypatch):
+def test_refresh_codex_credential_updates_auth_file(mock_urlopen, mock_chmod, tmp_path, monkeypatch):
     codex_home = tmp_path / "codex-home"
     codex_home.mkdir()
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
@@ -51,6 +52,9 @@ def test_refresh_codex_credential_updates_auth_file(mock_urlopen, tmp_path, monk
 
     assert credential is not None
     assert credential.access_token == "new-access"
+    assert credential.refresh_token == "new-refresh"
+    assert credential.account_id == "acct_123"
+    mock_chmod.assert_called_once_with(auth_path, 0o600)
     saved = json.loads(auth_path.read_text(encoding="utf-8"))
     assert saved["tokens"]["access_token"] == "new-access"
     assert saved["tokens"]["refresh_token"] == "new-refresh"

--- a/tests/test_codex_auth.py
+++ b/tests/test_codex_auth.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from kong.llm.codex_auth import refresh_codex_credential, resolve_codex_credential
+
+
+def test_resolve_codex_credential_reads_auth_file(tmp_path, monkeypatch):
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    (codex_home / "auth.json").write_text(json.dumps({
+        "tokens": {
+            "access_token": "oauth-token",
+            "refresh_token": "refresh-token",
+            "account_id": "acct_123",
+        },
+    }))
+
+    credential = resolve_codex_credential()
+
+    assert credential is not None
+    assert credential.access_token == "oauth-token"
+    assert credential.refresh_token == "refresh-token"
+    assert credential.account_id == "acct_123"
+
+
+@patch("kong.llm.codex_auth.urllib.request.urlopen")
+def test_refresh_codex_credential_updates_auth_file(mock_urlopen, tmp_path, monkeypatch):
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    auth_path = codex_home / "auth.json"
+    auth_path.write_text(json.dumps({
+        "tokens": {
+            "access_token": "old-access",
+            "refresh_token": "old-refresh",
+            "account_id": "acct_123",
+        },
+    }))
+
+    mock_response = mock_urlopen.return_value.__enter__.return_value
+    mock_response.read.return_value = json.dumps({
+        "access_token": "new-access",
+        "refresh_token": "new-refresh",
+        "expires_in": 3600,
+    }).encode("utf-8")
+
+    credential = refresh_codex_credential()
+
+    assert credential is not None
+    assert credential.access_token == "new-access"
+    saved = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert saved["tokens"]["access_token"] == "new-access"
+    assert saved["tokens"]["refresh_token"] == "new-refresh"
+    assert saved["tokens"]["account_id"] == "acct_123"

--- a/tests/test_codex_client.py
+++ b/tests/test_codex_client.py
@@ -60,6 +60,21 @@ def test_analyze_function_parses_json(mock_urlopen, mock_resolve_credential):
 
 @patch("kong.llm.codex_client.resolve_codex_credential")
 @patch("kong.llm.codex_client.urllib.request.urlopen")
+def test_analyze_function_handles_eof_without_trailing_blank_line(mock_urlopen, mock_resolve_credential):
+    mock_resolve_credential.return_value = MagicMock(access_token="oauth", account_id="acct", refresh_token="refresh")
+    mock_urlopen.return_value = _FakeStreamingResponse(
+        "event: response.completed\n"
+        f"data: {json.dumps({'response': {'output': [{'type': 'message', 'content': [{'type': 'output_text', 'text': json.dumps({'name': 'eof_case'})}]}], 'usage': {'input_tokens': 3, 'output_tokens': 2}}})}\n"
+    )
+
+    client = CodexClient(model="gpt-5-codex")
+    response = client.analyze_function("analyze this function")
+
+    assert response.name == "eof_case"
+
+
+@patch("kong.llm.codex_client.resolve_codex_credential")
+@patch("kong.llm.codex_client.urllib.request.urlopen")
 def test_analyze_with_tools_executes_tool_calls(mock_urlopen, mock_resolve_credential):
     mock_resolve_credential.return_value = MagicMock(access_token="oauth", account_id="acct", refresh_token="refresh")
     mock_urlopen.side_effect = [

--- a/tests/test_codex_client.py
+++ b/tests/test_codex_client.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from kong.llm.codex_client import CodexClient
+
+
+class _FakeStreamingResponse:
+    def __init__(self, body: str):
+        self._lines = iter(body.encode("utf-8").splitlines(keepends=True))
+
+    def readline(self) -> bytes:
+        return next(self._lines, b"")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def _completed_event(output: list[dict[str, object]], *, input_tokens: int = 10, output_tokens: int = 5) -> str:
+    return (
+        "event: response.completed\n"
+        f"data: {json.dumps({'response': {'output': output, 'usage': {'input_tokens': input_tokens, 'output_tokens': output_tokens}}})}\n\n"
+        "data: [DONE]\n\n"
+    )
+
+
+@patch("kong.llm.codex_client.resolve_codex_credential")
+@patch("kong.llm.codex_client.urllib.request.urlopen")
+def test_analyze_function_parses_json(mock_urlopen, mock_resolve_credential):
+    mock_resolve_credential.return_value = MagicMock(access_token="oauth", account_id="acct", refresh_token="refresh")
+    mock_urlopen.return_value = _FakeStreamingResponse(_completed_event([
+        {
+            "type": "message",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": json.dumps({
+                        "name": "hash_string",
+                        "confidence": 91,
+                        "classification": "string",
+                        "comments": "Hashes a string",
+                    }),
+                }
+            ],
+        }
+    ]))
+
+    client = CodexClient(model="gpt-5-codex")
+    response = client.analyze_function("analyze this function")
+
+    assert response.name == "hash_string"
+    assert response.confidence == 91
+    assert response.input_tokens == 10
+    assert response.output_tokens == 5
+
+
+@patch("kong.llm.codex_client.resolve_codex_credential")
+@patch("kong.llm.codex_client.urllib.request.urlopen")
+def test_analyze_with_tools_executes_tool_calls(mock_urlopen, mock_resolve_credential):
+    mock_resolve_credential.return_value = MagicMock(access_token="oauth", account_id="acct", refresh_token="refresh")
+    mock_urlopen.side_effect = [
+        _FakeStreamingResponse(_completed_event([
+            {
+                "type": "function_call",
+                "name": "lookup_symbol",
+                "call_id": "call_123",
+                "arguments": json.dumps({"name": "Foo"}),
+            }
+        ], input_tokens=20, output_tokens=4)),
+        _FakeStreamingResponse(_completed_event([
+            {
+                "type": "message",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": json.dumps({
+                            "name": "resolve_foo",
+                            "confidence": 88,
+                            "classification": "utility",
+                            "comments": "Uses the looked up symbol",
+                        }),
+                    }
+                ],
+            }
+        ], input_tokens=15, output_tokens=7)),
+    ]
+
+    executor = MagicMock()
+    executor.execute.return_value = '{"symbol":"Foo"}'
+
+    client = CodexClient(model="gpt-5-codex")
+    response = client.analyze_with_tools(
+        prompt="use tools",
+        system="system",
+        tools=[
+            {
+                "name": "lookup_symbol",
+                "description": "Lookup a symbol",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name"],
+                },
+            }
+        ],
+        tool_executor=executor,
+    )
+
+    executor.execute.assert_called_once_with("lookup_symbol", {"name": "Foo"})
+    assert response.name == "resolve_foo"
+    assert response.input_tokens == 35
+    assert response.output_tokens == 11

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,12 +7,16 @@ class TestLLMProviderCustom:
     def test_custom_variant_exists(self):
         assert LLMProvider.CUSTOM.value == "custom"
 
+    def test_codex_variant_exists(self):
+        assert LLMProvider.CODEX.value == "codex"
+
     def test_custom_display_name(self):
         assert LLMProvider.CUSTOM.display_name == "Custom"
 
     def test_existing_display_names_unchanged(self):
         assert LLMProvider.ANTHROPIC.display_name == "Anthropic"
         assert LLMProvider.OPENAI.display_name == "OpenAI"
+        assert LLMProvider.CODEX.display_name == "Codex"
 
 
 class TestLLMConfigCustomFields:

--- a/tests/test_openai_auth.py
+++ b/tests/test_openai_auth.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+
+from kong.llm.openai_auth import codex_auth_path, resolve_openai_credential
+
+
+def test_resolve_openai_credential_prefers_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-test")
+    auth_path = codex_auth_path()
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+    auth_path.write_text(json.dumps({
+        "OPENAI_API_KEY": "sk-codex-test",
+        "tokens": {"access_token": "oauth-token"},
+    }))
+
+    credential = resolve_openai_credential()
+
+    assert credential is not None
+    assert credential.source == "env"
+    assert credential.token == "sk-env-test"
+
+
+def test_resolve_openai_credential_uses_codex_api_key(monkeypatch, tmp_path):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    auth_path = codex_auth_path()
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+    auth_path.write_text(json.dumps({
+        "OPENAI_API_KEY": "sk-codex-test",
+        "tokens": {"access_token": "oauth-token"},
+    }))
+
+    credential = resolve_openai_credential()
+
+    assert credential is not None
+    assert credential.source == "codex_api_key"
+    assert credential.token == "sk-codex-test"
+
+
+def test_resolve_openai_credential_uses_codex_oauth(monkeypatch, tmp_path):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    auth_path = codex_auth_path()
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+    auth_path.write_text(json.dumps({
+        "OPENAI_API_KEY": None,
+        "tokens": {"access_token": "oauth-token"},
+    }))
+
+    credential = resolve_openai_credential()
+
+    assert credential is not None
+    assert credential.source == "codex_oauth"
+    assert credential.token == "oauth-token"

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -124,6 +124,42 @@ class TestProbeOpenAI:
         config = LLMConfig(provider=LLMProvider.OPENAI, api_key="bad-key")
         assert probe_endpoint(config) is False
 
+    @patch("kong.llm.probe.openai.OpenAI")
+    def test_openai_probe_falls_back_to_inference_when_model_list_scope_missing(self, mock_openai_cls):
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.models.list.side_effect = openai.PermissionDeniedError(
+            message="Missing scopes: api.model.read",
+            response=MagicMock(status_code=403),
+            body=None,
+        )
+        mock_client.chat.completions.create.return_value = MagicMock()
+
+        config = LLMConfig(provider=LLMProvider.OPENAI, api_key="oauth-token")
+
+        assert probe_endpoint(config) is True
+        mock_client.chat.completions.create.assert_called_once()
+
+
+class TestProbeCodex:
+    @patch("kong.llm.probe.CodexClient")
+    def test_codex_probe_success(self, mock_codex_cls):
+        mock_codex_cls.return_value.probe.return_value = True
+        config = LLMConfig(provider=LLMProvider.CODEX, model="gpt-5-codex")
+        assert probe_endpoint(config) is True
+        mock_codex_cls.assert_called_once_with(
+            model="gpt-5-codex",
+            max_output_tokens=None,
+        )
+
+    @patch("kong.llm.probe.CodexClient")
+    def test_codex_probe_failure(self, mock_codex_cls):
+        from kong.llm.codex_client import CodexClientError
+
+        mock_codex_cls.return_value.probe.side_effect = CodexClientError("bad auth")
+        config = LLMConfig(provider=LLMProvider.CODEX, model="gpt-5-codex")
+        assert probe_endpoint(config) is False
+
 
 class TestProbeAnthropic:
     @patch("kong.llm.probe.anthropic.Anthropic")

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -35,13 +36,32 @@ class TestSetupWizard:
         assert get_default_provider() is LLMProvider.OPENAI
         assert get_enabled_providers() == [LLMProvider.OPENAI]
 
+    def test_single_provider_openai_with_codex_oauth(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KONG_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        codex_home = tmp_path / "codex-home"
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        codex_home.mkdir(parents=True, exist_ok=True)
+        (codex_home / "auth.json").write_text(json.dumps({
+            "OPENAI_API_KEY": None,
+            "tokens": {"access_token": "oauth-token"},
+        }))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["setup"], input="2\n")
+
+        assert result.exit_code == 0
+        assert "Codex OAuth" in result.output
+        assert get_default_provider() is LLMProvider.OPENAI
+        assert get_enabled_providers() == [LLMProvider.OPENAI]
+
     def test_both_providers_default_anthropic(self, tmp_path, monkeypatch):
         monkeypatch.setenv("KONG_CONFIG_DIR", str(tmp_path))
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test1234")
         monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-test1234")
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["setup"], input="4\n1\n")
+        result = runner.invoke(cli, ["setup"], input="5\n1\n")
 
         assert result.exit_code == 0
         assert get_enabled_providers() == [LLMProvider.ANTHROPIC, LLMProvider.OPENAI]
@@ -53,10 +73,31 @@ class TestSetupWizard:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-test1234")
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["setup"], input="4\n2\n")
+        result = runner.invoke(cli, ["setup"], input="5\n2\n")
 
         assert result.exit_code == 0
         assert get_default_provider() is LLMProvider.OPENAI
+
+    def test_single_provider_codex(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KONG_CONFIG_DIR", str(tmp_path))
+        codex_home = tmp_path / "codex-home"
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        codex_home.mkdir(parents=True, exist_ok=True)
+        (codex_home / "auth.json").write_text(json.dumps({
+            "tokens": {
+                "access_token": "oauth-token",
+                "refresh_token": "refresh-token",
+                "account_id": "acct_123",
+            },
+        }))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["setup"], input="3\n")
+
+        assert result.exit_code == 0
+        assert "Codex" in result.output
+        assert get_default_provider() is LLMProvider.CODEX
+        assert get_enabled_providers() == [LLMProvider.CODEX]
 
     def test_shows_missing_key_instructions(self, tmp_path, monkeypatch):
         monkeypatch.setenv("KONG_CONFIG_DIR", str(tmp_path))


### PR DESCRIPTION
## Summary

This adds a first-class `codex` provider to Kong, backed by the ChatGPT Codex OAuth flow instead of the standard OpenAI API.

## What changed

- added `LLMProvider.CODEX`
- added `CodexClient` for ChatGPT Codex backend requests
- added `codex_auth` helpers for loading and refreshing local Codex OAuth credentials
- wired Codex into `kong setup`, provider resolution, endpoint probing, and CLI messaging
- kept existing `openai` and `custom` provider behavior intact
- added tests for Codex auth, Codex client flow, setup, probe, and provider routing
- updated README usage docs

## Why

Kong previously could reuse a local Codex login only as a credential source for the normal OpenAI API path. That still fails for accounts without OpenAI API billing.

This change adds a real Codex-backed path so users can run Kong through their local ChatGPT/Codex login directly.

## Verification

- `uv run pytest -q`
- full suite passing: `448 passed`
- local Codex probe verified successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a first-class `codex` provider that talks to the ChatGPT Codex backend via OAuth, independent of the OpenAI API. Users can run Kong with a local ChatGPT login; setup, probing, routing, and usage reporting were updated (tokens only, no cost).

- New Features
  - Added `LLMProvider.CODEX` and a Codex client with SSE streaming, tool-calling, token usage, and OAuth auto-refresh on 401s.
  - Auth: `codex_auth` loads/refreshes from `~/.codex/auth.json` (override with `CODEX_HOME`); `openai_auth` now auto-resolves `OPENAI_API_KEY`, Codex API key, or Codex OAuth; the OpenAI client re-resolves credentials dynamically.
  - Setup/UX: wizard adds `codex` and `Anthropic + Codex`, shows credential source labels, and guides to run `codex`; provider labels/help updated; default Codex model is `gpt-5-codex`; clearer errors when Codex login is missing or when OpenAI uses Codex OAuth without API billing.
  - Probing: Codex probe added; OpenAI probe falls back to an inference check if model-list scope is missing.
  - Usage/Export/Docs: treat `codex` as non-billable (token counts only; exports mark cost tracking off); README adds Codex sign-in (`codex`), `CODEX_HOME`, separate billing notes, and `--provider codex` examples.

- Migration
  - No breaking changes; `openai` and `custom` behavior unchanged.
  - To use Codex: run `codex` to sign in, then `kong setup` and choose `codex` (or `Anthropic + Codex`).
  - If `openai` runs via Codex OAuth and requests fail, enable OpenAI API billing or set `OPENAI_API_KEY`.

<sup>Written for commit 300ad957eeb302fb46d13e1300b6418b53b786ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

