### PR TITLE
update gitignore and pyproject structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,6 +228,9 @@ docs/
 corpus/
 
 tools/xda/data/
+tools/xda/models/
+tools/xda/checkpoints/
+tools/xda/corpus/
 
 # Added by cargo
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,3 @@ packages = ["kong"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
-[tool.uv.workspace]
-members = [
-    "tools/xda",
-]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ignore XDA model artifacts and datasets to keep the repo clean. Remove the `uv` workspace config to decouple `tools/xda` from the root build.

- **Refactors**
  - Added `.gitignore` entries for `tools/xda/models`, `tools/xda/checkpoints`, and `tools/xda/corpus`.
  - Removed `[tool.uv.workspace]` members list referencing `tools/xda` from `pyproject.toml`.

<sup>Written for commit 471e5d746b90eab4b5bda12e265247e376cd13ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

