### PR TITLE
* fix issue-17   The failure to decompile a single function directly …

### DIFF
--- a/kong/agent/supervisor.py
+++ b/kong/agent/supervisor.py
@@ -254,7 +254,26 @@ class Supervisor:
                 completed_count += 1
                 continue
 
-            decompilation = self._get_decompilation(func.address)
+            try:
+                decompilation = self._get_decompilation(func.address)
+            except Exception as e:
+                err_msg = _clean_api_error(e)
+                result = FunctionResult(
+                    address=func.address,
+                    original_name=func.name,
+                    error=err_msg,
+                )
+                self.results[func.address] = result
+                self.stats.record_result(result)
+                self._emit(Event(
+                    type=EventType.FUNCTION_ERROR,
+                    phase=Phase.ANALYSIS,
+                    message=f"Decompilation failed for {func.name}: {err_msg}",
+                    data={"address": func.address, "error": err_msg},
+                ))
+                completed_count += 1
+                continue
+
             techniques = classify_obfuscation(decompilation)
 
             if techniques:


### PR DESCRIPTION
…causes the entire analysis to crash

Add Exception Handling in the Pre-Decompilation Phase of Batch Analysis

Add a try-catch block inside the loop at  _run_analysis():

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent analysis from crashing when a single function fails to decompile. Errors are now captured per function, the batch continues, and an error event is emitted.

- **Bug Fixes**
  - Wrapped `_get_decompilation()` in a try/except inside `_run_analysis()`.
  - On failure, create a `FunctionResult` with `error`, record stats, and mark the function completed.
  - Emit `EventType.FUNCTION_ERROR` during `Phase.ANALYSIS` with function address and cleaned error.

<sup>Written for commit ceeba728b74c8ef4017df7f7873b50367136c6c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

