### PR TITLE
* fix issue-18 The decompilation phase takes an unusually long time w…

### DIFF
--- a/kong/agent/events.py
+++ b/kong/agent/events.py
@@ -50,6 +50,9 @@ class EventType(Enum):
     RUN_COMPLETE = "run_complete"
     RUN_ERROR = "run_error"
 
+    ANALYSIS_DECOMPILE_PROGRESS = "analysis_decompile_progress"
+    ANALYSIS_DECOMPILE_COMPLETE = "analysis_decompile_complete"
+
 
 @dataclass
 class Event:

--- a/kong/agent/supervisor.py
+++ b/kong/agent/supervisor.py
@@ -223,11 +223,13 @@ class Supervisor:
         ))
 
         all_items = self.queue.all_items()
+        total_items = len(all_items)
         chunk_items: list[tuple[WorkItem, str]] = []
         sequential_items: list[WorkItem] = []
         completed_count = 0
+        progress_reported = 0
 
-        for item in all_items:
+        for i, item in enumerate(all_items):
             func = item.function
 
             if func.classification and func.classification.value == "trivial":
@@ -262,6 +264,30 @@ class Supervisor:
                 continue
 
             chunk_items.append((item, normalize(decompilation)))
+
+            progress_threshold = 10
+            if i - progress_reported >= progress_threshold or i == total_items - 1:
+                progress_reported = i
+                self._emit(Event(
+                    type=EventType.ANALYSIS_DECOMPILE_PROGRESS,
+                    phase=Phase.ANALYSIS,
+                    message=f"Decompiling functions... {i+1}/{total_items}",
+                    data={
+                        "current": i + 1,
+                        "total": total_items,
+                        "percent": round((i + 1) / total_items * 100, 1),
+                    },
+                ))
+
+        self._emit(Event(
+            type=EventType.ANALYSIS_DECOMPILE_COMPLETE,
+            phase=Phase.ANALYSIS,
+            message=f"Decompilation complete. {len(chunk_items)} for batch, {len(sequential_items)} for sequential.",
+            data={
+                "batch_count": len(chunk_items),
+                "sequential_count": len(sequential_items),
+            },
+        ))
 
         if chunk_items:
             self._analyze_chunks(chunk_items, completed_count)


### PR DESCRIPTION
…ith no UI interaction, which can easily be mistaken for a crash or freeze

1. New Event Types (events.py:53-54) ANALYSIS_DECOMPILE_PROGRESS — decompilation progress event

ANALYSIS_DECOMPILE_COMPLETE — decompilation complete event

2. Decompilation Phase Progress Indicators (supervisor.py:226-309) Emit a progress event every 10 functions

Progress includes: current count / total count / percentage

After decompilation completes, emit a completion event showing the number of functions processed in batch and sequential modes

Expected Outcome
After the fix, users will now see during the decompilation phase:

Real-time progress like: *"Decompiling functions... 1234/44606 (2.8%)"*

A final message: "Decompilation complete. X for batch, Y for sequential."

No more mistaken assumptions that the program has frozen!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show real-time decompilation progress to prevent the UI from appearing frozen during long runs. Fixes issue-18 by adding progress and completion events emitted during analysis.

- New Features
  - Added `ANALYSIS_DECOMPILE_PROGRESS` and `ANALYSIS_DECOMPILE_COMPLETE` events.
  - Emit progress every 10 functions (and on the final item) with current, total, and percent; message: "Decompiling functions... {current}/{total}".
  - On completion, emit "Decompilation complete. X for batch, Y for sequential." with `batch_count` and `sequential_count` data.

<sup>Written for commit c80a65dbb2cbe7af5d19573c3f68180eb5bc9324. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

